### PR TITLE
Add support cache storage for saving tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ return [
 ];
 ```
 
-#####Database
+##### Database
 It means after migrating, a table will be created which your application needs to store verification tokens.
 
 > If you’re using another table name for `users` table or different column name for `mobile` phone or even `mobile_verification_tokens` table, you can customize their values in config file:
@@ -81,7 +81,7 @@ return [
     //...
 ];
 ```
-#####Cache
+##### Cache
 When using the `cache` driver, the token will be stored in a cache driver configured by your application. In this case, your application performance is more than when using database definitely.
 
 All right! Now you should migrate the database:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 
 ## Introduction
-Many web applications require users to verify their mobile numbers before using the application. Rather than forcing you to re-implement this on each application, this package provides convenient methods for sending and verifying mobile verification requests.
+Many web applications require users to verify their mobile phone numbers before using the application. Rather than forcing you to re-implement this on each application, this package provides convenient methods for sending and verifying mobile phone verification requests.
 
 ## Installation
 
@@ -45,7 +45,25 @@ To get started, you should publish the `config/mobile_verifier.php` config file 
 php artisan vendor:publish --provider="Fouladgar\MobileVerification\ServiceProvider" --tag="config"
 ```
 
-If you’re using another table name for `users` table or different column name for `mobile` or even `mobile_verification_tokens` table, you can customize their values in config file:
+### Token Storage
+After generating a token, we need to store that in a storage. This package supports two drivers: `cache` and `database` which the default driver is `database`. You may specify which storage driver you would like to be used for saving tokens in your application:
+```php
+// config/mobile_verifier.php
+
+<?php
+
+return [
+    /**
+    |Supported drivers: "cache", "database"
+    */
+    'token_storage' => 'database',
+];
+```
+
+#####Database
+It means after migrating, a table will be created which your application needs to store verification tokens.
+
+> If you’re using another table name for `users` table or different column name for `mobile` phone or even `mobile_verification_tokens` table, you can customize their values in config file:
 
 ```php
 // config/mobile_verifier.php
@@ -63,17 +81,19 @@ return [
     //...
 ];
 ```
+#####Cache
+When using the `cache` driver, the token will be stored in a cache driver configured by your application. In this case, your application performance is more than when using database definitely.
 
-And then migrate the database:
+All right! Now you should migrate the database:
 ```
 php artisan migrate
 ``` 
 
-The package migration will create a table your application needs to store verification tokens. Also, a `mobile_verified_at` column will be add to your `users` table to show user verification state.
+Depending on the `token_storage` config, the package migration will create a token table. Also, a `mobile_verified_at` and `mobile` column will be added to your `users` table to show user verification state and store user's mobile phone.
 
 ### Model Preparation
 
-In the following, verify that your `User` model implements the `Fouladgar\MobileVerification\Contracts\MustVerifyMobile` contract and use the `Fouladgar\MobileVerification\Concerns\MustVerifyMobile` trait:
+In the following, make sure your `User` model implements the `Fouladgar\MobileVerification\Contracts\MustVerifyMobile` contract and use the `Fouladgar\MobileVerification\Concerns\MustVerifyMobile` trait:
 
 ```php
 <?php
@@ -97,7 +117,7 @@ class User extends Authenticatable implements IMustVerifyMobile
 
 You can use any SMS service for sending verification messages such as `Nexmo`, `Twilio` or etc. For sending notifications via this package, first you need to implement the `Fouladgar\MobileVerification\Contracts\SMSClient` contract. This contract requires you to implement `sendMessage` method. 
 
-This method will return your SMS service API result via a `Payload` object which contains user **number** and **token** message:
+This method will return your SMS service API results via a `Payload` object which contains user **number** and **token** message:
 
 ```php
 <?php
@@ -122,12 +142,12 @@ class SampleSMSClient implements SMSClient
     // ...
 }
 ```
-> :information_source: In above example, `NexmoService` can be replaced with your chosen SMS service along with its respective method.
+> In above example, `NexmoService` can be replaced with your chosen SMS service along with its respective method.
 
 Next, you should set the your `SMSClient` class in config file:
 
 ```php
-// config/mobile_verification.php
+// config/mobile_verifier.php
 
 <?php
 
@@ -155,8 +175,7 @@ use Illuminate\Auth\Events\Registered;
 //...
 ```
 
-At this point, a notification message has been sent to user and you've done half of the job! 
-
+At this point, a notification message has been sent to user, and you've done half of the job! 
 
 ## Routing
 
@@ -190,7 +209,7 @@ curl -X POST \
 In order to change default routes prefix or routes themselves, you can customize them in config file:
 
 ```php
-// config/mobile_verification.php
+// config/mobile_verifier.php
 
 <?php
 
@@ -207,10 +226,10 @@ return [
 ];
 ```
 
-Also this package allows you to override default controller. To achieve this, you can extend your controller from `Fouladgar\MobileVerification\Http\Controllers\BaseVerificationController` and set your controller namespace in config file:
+Also, this package allows you to override default controller. To achieve this, you can extend your controller from `Fouladgar\MobileVerification\Http\Controllers\BaseVerificationController` and set your controller namespace in config file:
 
 ```php
-// config/mobile_verification.php
+// config/mobile_verifier.php
 
 <?php
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class User extends Authenticatable implements IMustVerifyMobile
 
 ### SMS Client
 
-You can use any SMS service for sending verification messages such as `Nexmo`, `Twilio` or etc. For sending notifications via this package, first you need to implement the `Fouladgar\MobileVerification\Contracts\SMSClient` contract. This contract requires you to implement `sendMessage` method. 
+You can use any SMS service for sending verification messages(it depends on your choice). For sending notifications via this package, first you need to implement the `Fouladgar\MobileVerification\Contracts\SMSClient` contract. This contract requires you to implement `sendMessage` method. 
 
 This method will return your SMS service API results via a `Payload` object which contains user **number** and **token** message:
 
@@ -129,6 +129,8 @@ use Fouladgar\MobileVerification\Notifications\Messages\Payload;
 
 class SampleSMSClient implements SMSClient
 {
+    protected $SMSService;
+
     /**
      * @param Payload $payload
      *
@@ -136,13 +138,16 @@ class SampleSMSClient implements SMSClient
      */
     public function sendMessage(Payload $payload)
     {
-        // return $this->NexmoService->send($payload->getTo(), $payload->getToken());
+        // preparing SMSService ...
+
+        return $this->SMSService
+                 ->send($payload->getTo(), $payload->getToken());
     }
 
     // ...
 }
 ```
-> In above example, `NexmoService` can be replaced with your chosen SMS service along with its respective method.
+> In above example, `SMSService` can be replaced with your chosen SMS service along with its respective method.
 
 Next, you should set the your `SMSClient` class in config file:
 
@@ -175,7 +180,7 @@ use Illuminate\Auth\Events\Registered;
 //...
 ```
 
-At this point, a notification message has been sent to user, and you've done half of the job! 
+At this point, a notification message has been sent to user automatically, and you've done half of the job! 
 
 ## Routing
 
@@ -203,6 +208,21 @@ curl -X POST \
       -H 'Accept: application/json' \
       -H 'Authorization: JWT_TOKEN'
 ```
+
+> Notice: You should choose a long with middleware which you are going to use them for above APIs through set it in config file:
+
+```php
+// config/mobile_verifier.php
+
+<?php
+
+return [
+
+    'middleware' => ['auth:sanctum'],
+
+    //...
+];
+``` 
 
 ### Customize Routes and Controller
 

--- a/config/config.php
+++ b/config/config.php
@@ -67,6 +67,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    |  Token Storage Driver
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define token "storage" driver. If you choose the "cache", the token will be stored
+    | in a cache driver configured by your application. Otherwise, a table will be created for storing tokens.
+    |
+    | Supported drivers: "cache", "database"
+    |
+    */
+    'token_storage' => 'database',
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Controller Namespace
     |--------------------------------------------------------------------------
     |

--- a/config/config.php
+++ b/config/config.php
@@ -131,5 +131,5 @@ return [
      | For example: 'web', 'auth', 'auth:api'
      |
      */
-    'middleware' => ['web', 'auth'],
+    'middleware' => ['auth'],
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -128,7 +128,7 @@ return [
      |--------------------------------------------------------------------------
      |
      | Here you can specify which middleware you want to use for the APIs
-     | For example: 'web', 'auth', 'auth:api'
+     | For example: 'web', 'auth', 'auth:api', 'auth:sanctum'
      |
      */
     'middleware' => ['auth'],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,33 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <file>src/Events/Verified.php</file>
-                <file>src/Notifications/Messages/Payload.php</file>
-                <file>src/ServiceProvider.php</file>
-                <file>src/Exceptions/SMSClientNotFoundException.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="DB_CONNECTION" value="testing"/>
-        <env name="APP_KEY" value="base64:AyJGOtNkX6q4z+XaeZv11xdtseDc4P0ZL5gw2fS2aMw="/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <file>src/Events/Verified.php</file>
+      <file>src/Notifications/Messages/Payload.php</file>
+      <file>src/ServiceProvider.php</file>
+      <file>src/Exceptions/SMSClientNotFoundException.php</file>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="DB_CONNECTION" value="testing"/>
+    <env name="APP_KEY" value="base64:AyJGOtNkX6q4z+XaeZv11xdtseDc4P0ZL5gw2fS2aMw="/>
+  </php>
 </phpunit>

--- a/resources/lang/en/mobile_verifier.php
+++ b/resources/lang/en/mobile_verifier.php
@@ -12,7 +12,7 @@ return [
     |
     */
     'successful_verification' => 'Your mobile has been verified successfully.',
-    'successful_resend'       => 'Your token has been resent successfully.',
+    'successful_resend'       => 'The token has been resent successfully.',
     'already_verified'        => 'Your mobile already has been verified.',
 
 ];

--- a/src/Concerns/MustVerifyMobile.php
+++ b/src/Concerns/MustVerifyMobile.php
@@ -3,7 +3,6 @@
 namespace Fouladgar\MobileVerification\Concerns;
 
 use Fouladgar\MobileVerification\Notifications\VerifyMobile as VerifyMobileNotification;
-use Illuminate\Config\Repository;
 
 trait MustVerifyMobile
 {
@@ -32,7 +31,19 @@ trait MustVerifyMobile
     }
 
     /**
+     * Get mobile phone field.
+     *
+     * @return string
+     */
+    public function getMobileField(): string
+    {
+        return config('mobile_verifier.mobile_column', 'mobile');
+    }
+
+    /**
      * Determine if the user has verified their mobile number.
+
+     * @return bool
      */
     public function hasVerifiedMobile(): bool
     {
@@ -41,6 +52,8 @@ trait MustVerifyMobile
 
     /**
      * Mark the given user's mobile as verified.
+     *
+     * @return bool
      */
     public function markMobileAsVerified(): bool
     {
@@ -57,6 +70,8 @@ trait MustVerifyMobile
 
     /**
      * Get the mobile number that should be used for verification.
+     *
+     * @return string
      */
     public function getMobileForVerification(): string
     {
@@ -66,18 +81,10 @@ trait MustVerifyMobile
     /**
      * Get the recipients of the given message.
      *
-     * @return mixed
+     * @return string
      */
     public function routeNotificationForVerificationMobile(): string
     {
         return $this->{$this->getMobileField()};
-    }
-
-    /**
-     * @return Repository|mixed
-     */
-    private function getMobileField()
-    {
-        return config('mobile_verifier.mobile_column', 'mobile');
     }
 }

--- a/src/Concerns/MustVerifyMobile.php
+++ b/src/Concerns/MustVerifyMobile.php
@@ -31,7 +31,7 @@ trait MustVerifyMobile
     }
 
     /**
-     * Get mobile phone field.
+     * Get mobile phone field name.
      *
      * @return string
      */

--- a/src/Concerns/Responses.php
+++ b/src/Concerns/Responses.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Fouladgar\MobileVerification\Concerns;
+
+use Illuminate\Http\JsonResponse;
+
+trait Responses
+{
+    /**
+     * @return JsonResponse
+     */
+    protected function successMessage(): JsonResponse
+    {
+        return response()->json(['message' => __('MobileVerification::mobile_verifier.successful_verification')], 200);
+    }
+
+    /**
+     * @return JsonResponse
+     */
+    protected function successResendMessage(): JsonResponse
+    {
+        return response()->json(['message' => __('MobileVerification::mobile_verifier.successful_resend')], 200);
+    }
+
+    /**
+     * @return JsonResponse
+     */
+    protected function unprocessableEntity(): JsonResponse
+    {
+        return response()->json(['message' => __('MobileVerification::mobile_verifier.already_verified')], 422);
+    }
+}

--- a/src/Concerns/VerifiesMobiles.php
+++ b/src/Concerns/VerifiesMobiles.php
@@ -5,12 +5,11 @@ namespace Fouladgar\MobileVerification\Concerns;
 use Fouladgar\MobileVerification\Events\Verified;
 use Fouladgar\MobileVerification\Exceptions\InvalidTokenException;
 use Fouladgar\MobileVerification\Http\Requests\VerificationRequest;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 trait VerifiesMobiles
 {
-    use RedirectsUsers;
+    use RedirectsUsers, Responses;
 
     /**
      * {@inheritdoc}
@@ -36,7 +35,7 @@ trait VerifiesMobiles
         return $request->expectsJson()
             ? $this->successMessage()
             : redirect($this->redirectPath())
-                ->with('mobileVerificationVerified', __('mobile_verifier.successful_verification'));
+                ->with('mobileVerificationVerified', __('MobileVerification::mobile_verifier.successful_verification'));
     }
 
     /**
@@ -53,23 +52,7 @@ trait VerifiesMobiles
         $this->tokenBroker->sendToken($user);
 
         return $request->expectsJson()
-            ? $this->successMessage()
-            : back()->with('mobileVerificationResend', __('mobile_verifier.successful_resend'));
-    }
-
-    /**
-     * @return JsonResponse
-     */
-    protected function successMessage(): JsonResponse
-    {
-        return response()->json(['message' => __('mobile_verifier.successful_verification')], 200);
-    }
-
-    /**
-     * @return JsonResponse
-     */
-    protected function unprocessableEntity(): JsonResponse
-    {
-        return response()->json(['message' => __('mobile_verifier.already_verified')], 422);
+            ? $this->successResendMessage()
+            : back()->with('mobileVerificationResend', __('MobileVerification::mobile_verifier.successful_resend'));
     }
 }

--- a/src/Contracts/MustVerifyMobile.php
+++ b/src/Contracts/MustVerifyMobile.php
@@ -21,7 +21,7 @@ interface MustVerifyMobile
     /**
      * Send the mobile verification notification.
      *
-     * @param string $token
+     * @param  string  $token
      *
      * @return void
      */
@@ -34,5 +34,10 @@ interface MustVerifyMobile
      */
     public function getMobileForVerification(): string;
 
-    public function getMobileField():string ;
+    /**
+     * Get mobile phone field name.
+     *
+     * @return string
+     */
+    public function getMobileField(): string;
 }

--- a/src/Contracts/MustVerifyMobile.php
+++ b/src/Contracts/MustVerifyMobile.php
@@ -33,4 +33,6 @@ interface MustVerifyMobile
      * @return string
      */
     public function getMobileForVerification(): string;
+
+    public function getMobileField():string ;
 }

--- a/src/Http/Requests/VerificationRequest.php
+++ b/src/Http/Requests/VerificationRequest.php
@@ -16,10 +16,8 @@ class VerificationRequest extends FormRequest
      */
     public function rules(): array
     {
-        $tokenLength = config('mobile_verifier.token_length', 5);
-
         return [
-            'token' => 'required|string|size:'.$tokenLength,
+            'token' => 'required|string|size:'. config('mobile_verifier.token_length', 5),
         ];
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -43,7 +43,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         Route::group(
             $this->routeConfiguration(),
-            function (){
+            function () {
                 $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
             }
         );
@@ -127,7 +127,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->app->singleton(
             SMSClient::class,
-            static function ($app){
+            static function ($app) {
                 try {
                     return $app->make(config('mobile_verifier.sms_client'));
                 } catch (Throwable $e) {
@@ -138,7 +138,7 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->bind(
             TokenRepositoryInterface::class,
-            static function ($app){
+            static function ($app) {
                 switch (config('mobile_verifier.token_storage', 'database')) {
                     case 'database':
                         return new DatabaseTokenRepository(
@@ -157,6 +157,7 @@ class ServiceProvider extends BaseServiceProvider
                             config('mobile_verifier.token_lifetime', 5),
                             config('mobile_verifier.token_length', 'mobile_verification_tokens')
                         );
+
                         break;
                     default:
                 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Fouladgar\MobileVerification;
 use Fouladgar\MobileVerification\Contracts\SMSClient;
 use Fouladgar\MobileVerification\Exceptions\SMSClientNotFoundException;
 use Fouladgar\MobileVerification\Http\Middleware\EnsureMobileIsVerified;
+use Fouladgar\MobileVerification\Tokens\CacheTokenRepository;
 use Fouladgar\MobileVerification\Tokens\DatabaseTokenRepository;
 use Fouladgar\MobileVerification\Tokens\TokenBroker;
 use Fouladgar\MobileVerification\Tokens\TokenBrokerInterface;
@@ -20,7 +21,7 @@ class ServiceProvider extends BaseServiceProvider
     /**
      * Perform post-registration booting of services.
      *
-     * @param Router $router
+     * @param  Router  $router
      */
     public function boot(Router $router): void
     {
@@ -34,29 +35,34 @@ class ServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * Register any package services.
-     *
-     * @return void
-     */
-    public function register(): void
-    {
-        $this->app->register(EventServiceProvider::class);
-
-        $this->mergeConfigFrom($this->getConfig(), 'mobile_verifier');
-
-        $this->registerBindings();
-    }
-
-    /**
      * Register the package routes.
      *
      * @return void
      */
     protected function registerRoutes(): void
     {
-        Route::group($this->routeConfiguration(), function () {
-            $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
-        });
+        Route::group(
+            $this->routeConfiguration(),
+            function (){
+                $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
+            }
+        );
+    }
+
+    /**
+     * Get the Telescope route group configuration array.
+     *
+     * @return array
+     */
+    private function routeConfiguration(): array
+    {
+        return [
+            'namespace' => config(
+                'mobile_verifier.controller_namespace',
+                'Fouladgar\MobileVerification\Http\Controllers'
+            ),
+            'prefix' => config('mobile_verifier.routes_prefix', 'auth'),
+        ];
     }
 
     /**
@@ -78,37 +84,14 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->publishes([$this->getConfig() => config_path('mobile_verifier.php')], 'config');
 
-        $this->publishes([
-            __DIR__.'/../resources/lang' => resource_path('lang/vendor/MobileVerification'),
-        ], 'lang');
+        $this->publishes(
+            [
+                __DIR__.'/../resources/lang' => resource_path('lang/vendor/MobileVerification'),
+            ],
+            'lang'
+        );
 
         $this->publishes([__DIR__.'/../database/migrations' => database_path('migrations')], 'migrations');
-    }
-
-    /**
-     * Register any package bindings.
-     *
-     * @return void
-     */
-    protected function registerBindings(): void
-    {
-        $this->app->singleton(SMSClient::class, static function ($app) {
-            try {
-                return $app->make(config('mobile_verifier.sms_client'));
-            } catch (Throwable $e) {
-                throw new SMSClientNotFoundException();
-            }
-        });
-
-        $this->app->bind(TokenRepositoryInterface::class, static function ($app) {
-            return new DatabaseTokenRepository(
-                $app->make(ConnectionInterface::class),
-                config('mobile_verifier.token_table', 'mobile_verification_tokens'),
-                config('mobile_verifier.token_lifetime', 5)
-            );
-        });
-
-        $this->app->bind(TokenBrokerInterface::class, TokenBroker::class);
     }
 
     /**
@@ -122,15 +105,64 @@ class ServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * Get the Telescope route group configuration array.
+     * Register any package services.
      *
-     * @return array
+     * @return void
      */
-    private function routeConfiguration(): array
+    public function register(): void
     {
-        return [
-            'namespace' => config('mobile_verifier.controller_namespace', 'Fouladgar\MobileVerification\Http\Controllers'),
-            'prefix' => config('mobile_verifier.routes_prefix', 'auth'),
-        ];
+        $this->app->register(EventServiceProvider::class);
+
+        $this->mergeConfigFrom($this->getConfig(), 'mobile_verifier');
+
+        $this->registerBindings();
+    }
+
+    /**
+     * Register any package bindings.
+     *
+     * @return void
+     */
+    protected function registerBindings(): void
+    {
+        $this->app->singleton(
+            SMSClient::class,
+            static function ($app){
+                try {
+                    return $app->make(config('mobile_verifier.sms_client'));
+                } catch (Throwable $e) {
+                    throw new SMSClientNotFoundException();
+                }
+            }
+        );
+
+        $this->app->bind(
+            TokenRepositoryInterface::class,
+            static function ($app){
+                switch (config('mobile_verifier.token_storage', 'database')) {
+                    case 'database':
+                        return new DatabaseTokenRepository(
+                            config('mobile_verifier.token_lifetime', 5),
+                            config('mobile_verifier.token_length', 5),
+                            config(
+                                'mobile_verifier.token_table',
+                                'mobile_verification_tokens'
+                            ),
+                            $app->make(ConnectionInterface::class)
+                        );
+//
+                        break;
+                    case 'cache':
+                        return new CacheTokenRepository(
+                            config('mobile_verifier.token_lifetime', 5),
+                            config('mobile_verifier.token_length', 'mobile_verification_tokens')
+                        );
+                        break;
+                    default:
+                }
+            }
+        );
+
+        $this->app->bind(TokenBrokerInterface::class, TokenBroker::class);
     }
 }

--- a/src/Tokens/AbstractTokenRepository.php
+++ b/src/Tokens/AbstractTokenRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Fouladgar\MobileVerification\Tokens;
+
+use Exception;
+use Illuminate\Support\Carbon;
+
+abstract class AbstractTokenRepository implements TokenRepositoryInterface
+{
+    /**
+     * The number of seconds a token should last.
+     *
+     * @var int
+     */
+    protected $expires;
+
+    /**
+     * @var int
+     */
+    protected $tokenLength;
+
+    /**
+     * Create a new token repository instance.
+     *
+     * @param  ConnectionInterface  $connection
+     * @param  string  $table
+     * @param  int  $expires
+     * @param  int  $tokenLength
+     */
+    public function __construct($expires, $tokenLength)
+    {
+        $this->expires = $expires;
+        $this->tokenLength = $tokenLength;
+    }
+
+    /**
+     * Set Expires token.
+     *
+     * @param  int  $expires
+     *
+     * @return $this
+     */
+    public function setExpires(int $expires)
+    {
+        $this->expires = $expires;
+
+        return $this;
+    }
+
+    /**
+     * Create a new token for the user.
+     *
+     * @throws Exception
+     *
+     * @return string
+     */
+    protected function createNewToken(): string
+    {
+        $tokenLength = config('mobile_verifier.token_length', 5);
+
+        return (string)random_int(10 ** ($tokenLength - 1), (10 ** $tokenLength) - 1);
+    }
+
+    /**
+     * Determine if the token has expired.
+     *
+     * @param  string  $expiresAt
+     *
+     * @return bool
+     */
+    protected function tokenExpired($expiresAt): bool
+    {
+        return Carbon::parse($expiresAt)->addMinutes($this->expires)->isPast();
+    }
+
+    /**
+     * Build the record payload for the table.
+     *
+     * @param $mobile
+     * @param  string  $token
+     *
+     * @throws Exception
+     *
+     * @return array
+     */
+    protected function getPayload($mobile, $token): array
+    {
+        return ['mobile' => $mobile, 'token' => $token];
+    }
+
+    /**
+     * Insert into storage token driver.
+     *
+     * @param $mobile
+     * @param $token
+     *
+     * @return bool
+     */
+    abstract protected function insertIntoStorageDriver($mobile, $token): bool;
+}

--- a/src/Tokens/CacheTokenRepository.php
+++ b/src/Tokens/CacheTokenRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Fouladgar\MobileVerification\Tokens;
+
+use Fouladgar\MobileVerification\Contracts\MustVerifyMobile;
+use Illuminate\Support\Facades\Cache;
+
+class CacheTokenRepository extends AbstractTokenRepository
+{
+    public function create(MustVerifyMobile $user): string
+    {
+        $mobile = $user->getMobileForVerification();
+
+        $this->deleteExisting($user);
+
+        $token = $this->createNewToken();
+
+        $this->insertIntoStorageDriver($mobile, $token);
+
+        return $token;
+    }
+
+    public function deleteExisting(MustVerifyMobile $user): ?int
+    {
+        return Cache::forget($user->getMobileForVerification());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function insertIntoStorageDriver($mobile, $token): bool
+    {
+        return Cache::add($mobile, $this->getPayload($mobile, $token), now()->addMinutes($this->expires));
+    }
+
+    public function exists($user, $token): bool
+    {
+        return Cache::has($user->getMobileForVerification()) &&
+            Cache::get($user->getMobileForVerification())['token'] == $token;
+    }
+}

--- a/src/Tokens/DatabaseTokenRepository.php
+++ b/src/Tokens/DatabaseTokenRepository.php
@@ -2,13 +2,11 @@
 
 namespace Fouladgar\MobileVerification\Tokens;
 
-use Exception;
 use Fouladgar\MobileVerification\Contracts\MustVerifyMobile;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Support\Carbon;
 
-class DatabaseTokenRepository implements TokenRepositoryInterface
+class DatabaseTokenRepository extends AbstractTokenRepository
 {
     /**
      * The database connection instance.
@@ -25,35 +23,22 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     protected $table;
 
     /**
-     * The number of seconds a token should last.
-     *
-     * @var int
-     */
-    protected $expires;
-
-    /**
-     * @var int
-     */
-    protected $tokenLength;
-
-    /**
      * Create a new token repository instance.
      *
-     * @param ConnectionInterface $connection
-     * @param string              $table
-     * @param int                 $expires
-     * @param int                 $tokenLength
+     * @param  ConnectionInterface  $connection
+     * @param  string  $table
+     * @param  int  $expires
+     * @param  int  $tokenLength
      */
     public function __construct(
-        ConnectionInterface $connection,
-        $table = 'mobile_verification_tokens',
-        $expires = 5,
-        $tokenLength = 5
-    ) {
+        $expires,
+        $tokenLength,
+        $table,
+        ConnectionInterface $connection
+    ){
+        parent::__construct($expires, $tokenLength);
         $this->table = $table;
-        $this->expires = $expires;
         $this->connection = $connection;
-        $this->tokenLength = $tokenLength;
     }
 
     /**
@@ -67,9 +52,17 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
 
         $token = $this->createNewToken();
 
-        $this->getTable()->insert($this->getPayload($mobile, $token));
+        $this->insertIntoStorageDriver($mobile, $token);
 
         return $token;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteExisting(MustVerifyMobile $user): ?int
+    {
+        return optional($this->getTable()->where('mobile', $user->getMobileForVerification()))->delete();
     }
 
     /**
@@ -82,12 +75,17 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
         return $this->connection->table($this->table);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function deleteExisting(MustVerifyMobile $user): ?int
+    protected function insertIntoStorageDriver($mobile, $token): bool
     {
-        return optional($this->getTable()->where('mobile', $user->getMobileForVerification()))->delete();
+        return $this->getTable()->insert($this->getPayload($mobile, $token));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getPayload($mobile, $token): array
+    {
+        return parent::getPayload($mobile, $token) + ['expires_at' => now()->addMinutes($this->expires)];
     }
 
     /**
@@ -96,52 +94,11 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     public function exists($user, $token): bool
     {
         /** @var MustVerifyMobile $user */
-        $record = (array) $this->getTable()
-            ->where('mobile', $user->getMobileForVerification())
+        $record = (array)$this->getTable()
+            ->where($user->getMobileField(), $user->getMobileForVerification())
             ->where('token', $token)
             ->first();
 
         return $record && ! $this->tokenExpired($record['expires_at']);
-    }
-
-    /**
-     * Build the record payload for the table.
-     *
-     * @param $mobile
-     * @param string $token
-     *
-     * @throws Exception
-     *
-     * @return array
-     */
-    protected function getPayload($mobile, $token): array
-    {
-        return ['mobile' => $mobile, 'token' => $token, 'expires_at' => now()->addMinutes($this->expires)];
-    }
-
-    /**
-     * Create a new token for the user.
-     *
-     * @throws Exception
-     *
-     * @return string
-     */
-    protected function createNewToken(): string
-    {
-        $tokenLength = config('mobile_verifier.token_length', 5);
-
-        return (string) random_int(10 ** ($tokenLength - 1), (10 ** $tokenLength) - 1);
-    }
-
-    /**
-     * Determine if the token has expired.
-     *
-     * @param string $expiresAt
-     *
-     * @return bool
-     */
-    protected function tokenExpired($expiresAt): bool
-    {
-        return Carbon::parse($expiresAt)->addMinutes($this->expires)->isPast();
     }
 }

--- a/src/Tokens/DatabaseTokenRepository.php
+++ b/src/Tokens/DatabaseTokenRepository.php
@@ -35,7 +35,7 @@ class DatabaseTokenRepository extends AbstractTokenRepository
         $tokenLength,
         $table,
         ConnectionInterface $connection
-    ){
+    ) {
         parent::__construct($expires, $tokenLength);
         $this->table = $table;
         $this->connection = $connection;

--- a/tests/CacheTokenRepositoryTest.php
+++ b/tests/CacheTokenRepositoryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Fouladgar\MobileVerification\Tests;
+
+use Exception;
+use Fouladgar\MobileVerification\Tests\Models\VerifiableUser;
+use Fouladgar\MobileVerification\Tokens\CacheTokenRepository;
+use Fouladgar\MobileVerification\Tokens\TokenRepositoryInterface;
+use Illuminate\Support\Facades\Cache;
+use ReflectionMethod;
+
+class CacheTokenRepositoryTest extends TestCase
+{
+    /**
+     * @var CacheTokenRepository
+     */
+    private $tokenRepository;
+
+    private $insertIntoStorageDriver;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        app('config')->set('mobile_verifier.token_storage', 'cache');
+
+        Cache::flush();
+
+        $this->insertIntoStorageDriver = new ReflectionMethod(CacheTokenRepository::class, 'insertIntoStorageDriver');
+        $this->insertIntoStorageDriver->setAccessible(true);
+        $this->tokenRepository = $this->app->make(TokenRepositoryInterface::class);
+    }
+
+    /** @test
+     * @throws Exception
+     */
+    public function it_can_successfully_create_a_token()
+    {
+        $payload = ['mobile' => '093895999530'];
+        $user = new VerifiableUser($payload);
+        $token = $this->tokenRepository->create($user);
+        $payload['token'] = $token;
+
+        $this->assertEquals(Cache::get($payload['mobile']), $payload);
+    }
+
+    /** @test
+     * @throws Exception
+     */
+    public function it_can_successfully_delete_existing_token()
+    {
+        $user = new VerifiableUser(['mobile' => '555555']);
+
+        $record = [
+            'mobile' => '555555',
+            'token' => 'token_123',
+        ];
+
+        $this->insertIntoStorageDriver->invoke($this->tokenRepository, $record['mobile'], $record['token']);
+
+        $this->tokenRepository->deleteExisting($user);
+
+        $this->assertNull(Cache::get($record['mobile']));
+    }
+
+    /** @test
+     * @throws Exception
+     */
+    public function it_can_successfully_find_existing_and_not_expired_token()
+    {
+        $user = new VerifiableUser(['mobile' => '555555']);
+
+        $record = [
+            'mobile' => '555555',
+            'token' => 'token_123',
+        ];
+
+        $this->insertIntoStorageDriver->invoke($this->tokenRepository, $record['mobile'], $record['token']);
+
+        $this->assertTrue($this->tokenRepository->exists($user, $record['token']));
+    }
+
+    /** @test
+     * @throws Exception
+     */
+    public function it_fails_when_token_is_exist_but_expired()
+    {
+        $user = new VerifiableUser(['mobile' => '555555']);
+
+        $record = [
+            'mobile' => '555555',
+            'token' => 'token_123',
+        ];
+
+        $this->tokenRepository->setExpires(-5);
+        $this->insertIntoStorageDriver->invoke($this->tokenRepository, $record['mobile'], $record['token']);
+
+        $this->assertFalse($this->tokenRepository->exists($user, $record['token']));
+    }
+
+    /** @test
+     * @throws Exception
+     */
+    public function it_fails_when_token_is_not_existed()
+    {
+        $user = new VerifiableUser(['mobile' => '555555']);
+
+        $record = [
+            'mobile' => '555555',
+            'token' => 'token_123',
+        ];
+
+        $this->insertIntoStorageDriver->invoke($this->tokenRepository, $record['mobile'], $record['token']);
+
+        $this->assertFalse($this->tokenRepository->exists($user, 'token_123456'));
+    }
+}

--- a/tests/DatabaseTokenRepositoryTest.php
+++ b/tests/DatabaseTokenRepositoryTest.php
@@ -5,13 +5,13 @@ namespace Fouladgar\MobileVerification\Tests;
 use Exception;
 use Fouladgar\MobileVerification\Tests\Models\VerifiableUser;
 use Fouladgar\MobileVerification\Tokens\DatabaseTokenRepository;
+use Fouladgar\MobileVerification\Tokens\TokenRepositoryInterface;
 use Illuminate\Config\Repository;
-use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Str;
 use ReflectionMethod;
 
-class TokenRepositoryTest extends TestCase
+class DatabaseTokenRepositoryTest extends TestCase
 {
     /**
      * @var Builder
@@ -40,15 +40,12 @@ class TokenRepositoryTest extends TestCase
     {
         parent::setUp();
 
-        $tokenRepository = new DatabaseTokenRepository(
-            app(ConnectionInterface::class)
-        );
+        $this->tokenRepository = $this->app->make(TokenRepositoryInterface::class);
 
         $method = new ReflectionMethod(DatabaseTokenRepository::class, 'getTable');
         $method->setAccessible(true);
 
-        $this->table = $method->invoke($tokenRepository);
-        $this->tokenRepository = $tokenRepository;
+        $this->table = $method->invoke($this->tokenRepository);
         $this->tokenLength = config('mobile_verifier.token_length');
         $this->tokenLifetime = config('mobile_verifier.token_lifetime');
     }

--- a/tests/MobileVerificationControllerTest.php
+++ b/tests/MobileVerificationControllerTest.php
@@ -35,7 +35,7 @@ class MobileVerificationControllerTest extends TestCase
     }
 
     /** @test */
-    public function it_failes_on_verifing_when_user_is_already_verified()
+    public function it_fails_on_verifying_when_user_has_already_verified()
     {
         $user = factory(VerifiableUser::class)->state('verified')->create();
 
@@ -68,7 +68,7 @@ class MobileVerificationControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_fails_on_verifing_a_user()
+    public function it_fails_on_verifying_a_user()
     {
         $user = factory(VerifiableUser::class)->create();
 
@@ -84,7 +84,7 @@ class MobileVerificationControllerTest extends TestCase
     /**
      * @test
      */
-    public function it_failes_on_resend_when_user_is_already_verified()
+    public function it_fails_on_resend_when_user_is_already_verified()
     {
         $user = factory(VerifiableUser::class)->state('verified')->create();
 

--- a/tests/MobileVerificationControllerTest.php
+++ b/tests/MobileVerificationControllerTest.php
@@ -27,7 +27,7 @@ class MobileVerificationControllerTest extends TestCase
 
         $this->postJson(route('mobile.verify'), ['token' => '12345'])
             ->assertOk()
-            ->assertJson(['message' => __('mobile_verifier.successful_verification')]);
+            ->assertJson(['message' => __('MobileVerification::mobile_verifier.successful_verification')]);
 
         $this->post(route('mobile.verify'), ['token' => '12345'])
             ->assertStatus(Response::HTTP_FOUND)
@@ -43,7 +43,7 @@ class MobileVerificationControllerTest extends TestCase
 
         $this->postJson(route('mobile.verify'), ['token' => '12345'])
             ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
-            ->assertJson(['message' => __('mobile_verifier.already_verified')]);
+            ->assertJson(['message' => __('MobileVerification::mobile_verifier.already_verified')]);
 
         $this->post(route('mobile.verify'), ['token' => '12345'])
             ->assertStatus(Response::HTTP_FOUND);
@@ -93,7 +93,7 @@ class MobileVerificationControllerTest extends TestCase
         $this->postJson(route('mobile.resend'))
             ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
             ->assertJson([
-                'message' => __('mobile_verifier.already_verified'),
+                'message' => __('MobileVerification::mobile_verifier.already_verified'),
             ]);
 
         $this->post(route('mobile.resend'))

--- a/tests/Models/VerifiableUser.php
+++ b/tests/Models/VerifiableUser.php
@@ -2,7 +2,7 @@
 
 namespace Fouladgar\MobileVerification\Tests\Models;
 
-use Fouladgar\MobileVerification\Concerns\MustVerifyMobile as MustVerifyMobile;
+use Fouladgar\MobileVerification\Concerns\MustVerifyMobile;
 use Fouladgar\MobileVerification\Contracts\MustVerifyMobile as IMustVerifyMobile;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;

--- a/tests/VerificationChannelTest.php
+++ b/tests/VerificationChannelTest.php
@@ -29,7 +29,7 @@ class VerificationChannelTest extends TestCase
     }
 
     /** @test */
-    public function it_not_working_on_not_vefifable_user_model()
+    public function it_not_working_on_not_verifiable_user_model()
     {
         $notification = new VerifyMobile('token_123');
         $notifiable = new User();


### PR DESCRIPTION
Before this PR, you just could store tokens in the database. But now, you able to store the SMS tokens in the `Cache` storage by adjusting `token_storage` in the `mobile_verifier.php` config file.
```php
<?PHP
return [
...
 /*
    |--------------------------------------------------------------------------
    |  Token Storage Driver
    |--------------------------------------------------------------------------
    |
    | Here you may define token "storage" driver. If you choose the "cache", the token will be stored
    | in a cache driver configured by your application. Otherwise, a table will be created for storing tokens.
    |
    | Supported drivers: "cache", "database"
    |
    */
    'token_storage' => 'database',
...
];
```