### PR TITLE
fix for verify phone error when mobile column other than default

### DIFF
--- a/resources/lang/en/mobile_verifier.php
+++ b/resources/lang/en/mobile_verifier.php
@@ -14,5 +14,5 @@ return [
     'successful_verification' => 'Your mobile has been verified successfully.',
     'successful_resend'       => 'The token has been resent successfully.',
     'already_verified'        => 'Your mobile already has been verified.',
-
+    'expired_or_invalid' => 'The token has been expired or invalid.',
 ];

--- a/resources/lang/en/mobile_verifier.php
+++ b/resources/lang/en/mobile_verifier.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-
+    
     /*
     |--------------------------------------------------------------------------
     | Mobile Verifier Language file
@@ -14,5 +14,6 @@ return [
     'successful_verification' => 'Your mobile has been verified successfully.',
     'successful_resend'       => 'The token has been resent successfully.',
     'already_verified'        => 'Your mobile already has been verified.',
-    'expired_or_invalid' => 'The token has been expired or invalid.',
+    'expired_or_invalid'      => 'The token has been expired or invalid.',
+    'not_verified'            => 'Your mobile number is not verified.',
 ];

--- a/src/Exceptions/InvalidTokenException.php
+++ b/src/Exceptions/InvalidTokenException.php
@@ -11,6 +11,6 @@ class InvalidTokenException extends Exception
      */
     public function __construct()
     {
-        parent::__construct('The token has been expired or invalid.', 406);
+        parent::__construct(__('MobileVerification::mobile_verifier.expired_or_invalid'), 406);
     }
 }

--- a/src/Http/Middleware/EnsureMobileIsVerified.php
+++ b/src/Http/Middleware/EnsureMobileIsVerified.php
@@ -24,8 +24,8 @@ class EnsureMobileIsVerified
 
         if (! $user || ($user instanceof MustVerifyMobile && ! $user->hasVerifiedMobile())) {
             return $request->expectsJson()
-                ? abort(403, 'Your mobile number is not verified.')
-                : redirect('/')->withErrors(['mobile' => 'Your mobile number is not verified.']);
+                ? abort(403, __('MobileVerification::mobile_verifier.not_verified'))
+                : redirect('/')->withErrors(['mobile' => __('MobileVerification::mobile_verifier.not_verified')]);
         }
 
         return $next($request);

--- a/src/Tokens/DatabaseTokenRepository.php
+++ b/src/Tokens/DatabaseTokenRepository.php
@@ -85,7 +85,7 @@ class DatabaseTokenRepository extends AbstractTokenRepository
     public function exists(MustVerifyMobile $user, string $token): bool
     {
         $record = (array) $this->getTable()
-            ->where($user->getMobileField(), $user->getMobileForVerification())
+            ->where('mobile', $user->getMobileForVerification())
             ->where('token', $token)
             ->first();
 


### PR DESCRIPTION
{ "message": "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'phone' in 'where clause' (SQL: select * from `phone_verification_tokens` where `phone` = +79090060846 and `token` = 43052 limit 1)"

when /verify route

when config.mobile_column = 'phone'